### PR TITLE
feat: add unsafe mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ The Relay comes with pre-set TLS certificates configured during build time, so y
   The default port for the Middleware Endpoint is 3001, but you can change this by setting the downlink_port in your (configuration file)[#configuration-file-and-environment-variables].
 Repl
 3. **Local Testing**:
-  For local testing, you can use tools like ngrok or tailscale to expose your local server to the internet securely.
+  For local testing, you can use tools like ngrok or tailscale to expose your local server to the internet securely. Ensure to run the relay with the `--unsafe-mode` flag.
+
+  ```sh
+  tagoio-relay start --unsafe-mode
+  ```
 
   **Using Ngrok:**
   ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,10 @@ enum Commands {
     /// Path to the configuration file
     #[arg(short, long)]
     config_path: Option<String>,
+
+    /// Unsafe mode: disable SSL verification
+    #[arg(long)]
+    unsafe_mode: bool,
   },
 }
 
@@ -97,6 +101,7 @@ async fn main() {
     Commands::Start {
       verbose: _,
       config_path,
+      unsafe_mode,
     } => {
       let config = utils::fetch_config_file(config_path.clone());
       if let Some(config) = config {
@@ -106,7 +111,7 @@ async fn main() {
         std::process::exit(1);
       }
 
-      if let Err(e) = relay::start_relay().await {
+      if let Err(e) = relay::start_relay(*unsafe_mode).await {
         log::error!("Error starting relay: {}", e);
       }
     }


### PR DESCRIPTION
# Add --unsafe-mode to start command

## Description
This PR introduces a new `--unsafe-mode` option to the start command. When enabled, this mode disables TagoIO SSL Certificate verification, which can be beneficial for local testing scenarios, particularly when using ngrok.

## Changes
- Added `--unsafe-mode` flag to the start command
- Implemented logic to disable SSL Certificate verification when the flag is present

## Purpose
The primary purpose of this change is to facilitate easier local testing. By disabling SSL Certificate verification, developers can use tools like ngrok for local development and testing without encountering SSL-related issues.

## Usage
To use this new feature, simply add the `--unsafe-mode` flag when running the start command:
```
tago-cli start --unsafe-mode
```

